### PR TITLE
Update rake to a non-vulnerable version

### DIFF
--- a/adaptable_interface.gemspec
+++ b/adaptable_interface.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
Updates Rake to a non-vulnerable version, 13.0.1. This change has been tested by running the RSpec dependency. 